### PR TITLE
Unflatten into objects with integer keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ var unflatten = flat.unflatten = function (target, opts) {
 
         while (secondNibble !== undefined) {
             if (recipient[firstNibble] === undefined) {
-                recipient[firstNibble] = ((typeof secondNibble === 'number') ? [] : {})
+                recipient[firstNibble] = ((typeof secondNibble === 'number') && !opts.object ? [] : {})
             }
 
             recipient = recipient[firstNibble]

--- a/test/test.js
+++ b/test/test.js
@@ -231,6 +231,43 @@ suite('Unflatten', function() {
             })
         })
     })
+
+    suite('.object', function() {
+        test('Should create object instead of array when true', function() {
+            assert.deepEqual({
+                hello: {
+                    you: {
+                        0: 'ipsum',
+                        1: 'lorem',
+                    },
+                    other: { world: 'foo' }
+                }
+            }, unflatten(
+                {
+                'hello.you.0': 'ipsum',
+                'hello.you.1': 'lorem',
+                'hello.other.world': 'foo'
+            }, {
+                object: true
+            }));
+        })
+
+        test('Should not create object when false', function() {
+            assert.deepEqual({
+                hello: {
+                    you: ['ipsum', 'lorem'],
+                    other: { world: 'foo' }
+                }
+            }, unflatten(
+                {
+                'hello.you.0': 'ipsum',
+                'hello.you.1': 'lorem',
+                'hello.other.world': 'foo'
+            }, {
+                object: false
+            }));
+        })
+    })
 });
 
 suite('Arrays', function() {


### PR DESCRIPTION
Added `object` option to unflatten. When set to true, numbered keys are unflatten into objects with integer keys (instead of always creating arrays).

``` javascript
unflatten({
    'hello.you.0': 'ipsum',
    'hello.you.1': 'lorem',
    'hello.other.world': 'foo'
}, { object: true })

// =>

hello: {
    you: {
        0: 'ipsum',
        1: 'lorem',
    },
    other: { world: 'foo' }
}
```
