### PR TITLE
Fix unflatten for nested objects with numeric indices

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ function unflatten(target, opts) {
     }
 
     // unflatten again for 'messy objects'
-    recipient[key1] = unflatten(target[key])
+    recipient[key1] = unflatten(target[key], opts)
   })
 
   return result

--- a/test/test.js
+++ b/test/test.js
@@ -237,6 +237,13 @@ suite('Unflatten', function() {
 
   suite('.object', function() {
     test('Should create object instead of array when true', function() {
+      var unflattened = unflatten({
+        'hello.you.0': 'ipsum',
+        'hello.you.1': 'lorem',
+        'hello.other.world': 'foo'
+      }, {
+        object: true
+      });
       assert.deepEqual({
         hello: {
           you: {
@@ -245,30 +252,47 @@ suite('Unflatten', function() {
           },
           other: { world: 'foo' }
         }
-      }, unflatten(
-        {
-        'hello.you.0': 'ipsum',
-        'hello.you.1': 'lorem',
-        'hello.other.world': 'foo'
+      }, unflattened);
+      assert(!Array.isArray(unflattened.hello.you));
+    })
+
+    test('Should create object instead of array when nested', function() {
+      var unflattened = unflatten({
+        'hello': {
+          'you.0': 'ipsum',
+          'you.1': 'lorem',
+          'other.world': 'foo'
+        }
       }, {
         object: true
-      }))
+      });
+      assert.deepEqual({
+        hello: {
+          you: {
+            0: 'ipsum',
+            1: 'lorem',
+          },
+          other: { world: 'foo' }
+        }
+      }, unflattened);
+      assert(!Array.isArray(unflattened.hello.you));
     })
 
     test('Should not create object when false', function() {
-      assert.deepEqual({
-        hello: {
-          you: ['ipsum', 'lorem'],
-          other: { world: 'foo' }
-        }
-      }, unflatten(
-        {
+      var unflattened = unflatten({
         'hello.you.0': 'ipsum',
         'hello.you.1': 'lorem',
         'hello.other.world': 'foo'
       }, {
         object: false
-      }))
+      });
+      assert.deepEqual({
+        hello: {
+          you: ['ipsum', 'lorem'],
+          other: { world: 'foo' }
+        }
+      }, unflattened);
+      assert(Array.isArray(unflattened.hello.you));
     })
   })
 })


### PR DESCRIPTION
Options need to be passed through to the recursive call, so that .safe
and .object are still applied to nested objects.
