### PR TITLE
Overwrite keys when they cannot store new nested value

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,23 @@ unflatten({
 //     other: { world: 'foo' }
 // }
 ```
+
+### overwrite
+
+When enabled, existing keys in the unflattened object may be overwritten if they cannot hold a newly encountered nested value:
+
+```javascript
+unflatten({
+    'TRAVIS': 'true',
+    'TRAVIS_DIR': '/home/travis/build/kvz/environmental'
+}, { overwrite: true })
+
+// TRAVIS: {
+//     DIR: '/home/travis/build/kvz/environmental'
+// }
+```
+
+Without `overwrite` set to `true`, the `TRAVIS` key would already have been set to a string, thus could not accept the nested `DIR` element.
+
+This only makes sense on ordered arrays, and since we're overwriting data, should be used with care.
+

--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ function unflatten(target, opts) {
   opts = opts || {}
 
   var delimiter = opts.delimiter || '.'
+  var overwrite = opts.overwrite || false
   var result = {}
 
   if (Object.prototype.toString.call(target) !== '[object Object]') {
@@ -64,7 +65,13 @@ function unflatten(target, opts) {
     var recipient = result
 
     while (key2 !== undefined) {
-      if (recipient[key1] === undefined) {
+      var type = Object.prototype.toString.call(recipient[key1])
+      var isobject = (
+        type === "[object Object]" ||
+        type === "[object Array]"
+      )
+
+      if ((overwrite && !isobject) || (!overwrite && recipient[key1] === undefined)) {
         recipient[key1] = (
           typeof key2 === 'number' &&
           !opts.object ? [] : {}

--- a/test/test.js
+++ b/test/test.js
@@ -163,6 +163,22 @@ suite('Unflatten', function() {
     }))
   })
 
+  test('Overwrite', function() {
+    assert.deepEqual({
+      travis: {
+        build: {
+          dir: "/home/travis/build/kvz/environmental"
+        }
+      }
+    }, unflatten({
+      travis: "true",
+      travis_build_dir: "/home/travis/build/kvz/environmental"
+    }, {
+      delimiter: '_',
+      overwrite: true,
+    }))
+  })
+
   test('Messy', function() {
     assert.deepEqual({
       hello: { world: 'again' },


### PR DESCRIPTION
Instead of throwing an exception. Fixes https://github.com/hughsk/flat/issues/9