### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "test": "mocha -u tdd --reporter spec"
   },
-  "license": "BSD",
+  "license": "BSD-3-Clause",
   "description": "Take a nested Javascript object and flatten it, or unflatten an object with delimited keys",
   "devDependencies": {
     "mocha": "~1.6.0"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/

switching to SPDX compliant string: https://spdx.org/licenses/