### PR TITLE
unflatten regular array entries

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,11 +52,9 @@ function unflatten(target, opts) {
 
   // if an array is passed unflatten each entry
   if (Object.prototype.toString.call(target) === '[object Array]') {
-    var r = [];
-    target.map(function(entry){
-      r.push(unflatten(entry, opts));
+    return target.map(function(entry){
+       return unflatten(entry, opts);
     });
-    return r;
   }
 
   var isbuffer = isBuffer(target)

--- a/index.js
+++ b/index.js
@@ -50,6 +50,15 @@ function unflatten(target, opts) {
   var overwrite = opts.overwrite || false
   var result = {}
 
+  // if an array is passed unflatten each entry
+  if (Object.prototype.toString.call(target) === '[object Array]') {
+    var r = [];
+    target.map(function(entry){
+      r.push(unflatten(entry, opts));
+    });
+    return r;
+  }
+
   var isbuffer = isBuffer(target)
   if (isbuffer || Object.prototype.toString.call(target) !== '[object Object]') {
     return target

--- a/test/test.js
+++ b/test/test.js
@@ -409,6 +409,15 @@ suite('Arrays', function() {
     }))
   })
 
+  test('Should be able to unflatten flat objects inside a regular array', function() {
+    assert.deepEqual(
+      [{ 'f' : { 'data' : 'foo'}}, { 'b' : { 'data' : 'bar'}}]
+    , unflatten([
+        {'f.data': 'foo'}
+      , {'b.data': 'bar'}
+    ]))
+  })
+
   test('Array typed objects should be restored by unflatten', function () {
     assert.equal(
         Object.prototype.toString.call(['foo', 'bar'])


### PR DESCRIPTION
Usecase: Database can't handle nested json objects on input but can generate nested objects on output.
I get something like [{flatObject}, {flatObject}, {c : [{flatObject}, ... ]}, ...] from the database and want to unflatten it in one pass.

This change passes all array entries to unflatten when target is an array.