### PR TITLE
Fix flatten for nested objects with custom depth

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@ function flatten(target, opts) {
 
   var delimiter = opts.delimiter || '.'
   var maxDepth = opts.maxDepth
-  var currentDepth = 1
   var output = {}
 
   function step(object, prev) {
@@ -25,12 +24,13 @@ function flatten(target, opts) {
         ? prev + delimiter + key
         : key
 
+      var currentDepth = newKey.split(delimiter).length
+
       if (!opts.maxDepth) {
         maxDepth = currentDepth + 1;
       }
 
       if (!isarray && !isbuffer && isobject && Object.keys(value).length && currentDepth < maxDepth) {
-        ++currentDepth
         return step(value, newKey)
       }
 


### PR DESCRIPTION
The currentDepth was fixed so as to generate from newKey.