### PR TITLE
Added `check` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,3 +158,33 @@ flatten({
 //   'key3.a': { b: { c: 2 } }
 // }
 ```
+
+### check
+
+Check value for some condition. If returns `true` value will be flattened.
+
+```javascript
+var flatten = require('flat')
+
+flatten({
+  hello: {
+    world: {
+      again: 'good morning'
+    },
+    everyone: {
+      again: 'good evening'
+    }
+  }
+}, {
+    check: function(value) {
+        return value.again != 'good morning'
+    }
+})
+
+// {
+//   'hello.world': {
+//     again: 'good morning'
+//   },
+//   'hello.everyone.again': 'good evening'
+// }
+```

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ function flatten(target, opts) {
   var maxDepth = opts.maxDepth
   var currentDepth = 1
   var output = {}
+  var check = opts.check || function() {return true}
 
   function step(object, prev) {
     Object.keys(object).forEach(function(key) {
@@ -29,7 +30,7 @@ function flatten(target, opts) {
         maxDepth = currentDepth + 1;
       }
 
-      if (!isarray && !isbuffer && isobject && Object.keys(value).length && currentDepth < maxDepth) {
+      if (!isarray && !isbuffer && isobject && check(value) && Object.keys(value).length && currentDepth < maxDepth) {
         ++currentDepth
         return step(value, newKey)
       }

--- a/test/test.js
+++ b/test/test.js
@@ -154,6 +154,24 @@ suite('Flatten', function() {
       }
     })
   })
+
+  test('Custom Checker', function() {
+    assert.deepEqual(flatten({
+      hello: {
+        world: {
+          again: 'good morning'
+        },
+        everyone: {
+          again: 'good evening'
+        }
+      }
+    }, {check: function(value) {return value.again != 'good morning'}}), {
+      'hello.world': {
+          again: 'good morning'
+      },
+      'hello.everyone.again': 'good evening'
+    })
+  })
 })
 
 suite('Unflatten', function() {


### PR DESCRIPTION
Function that will check for should value be flattened or not.

Example:

```js
const SCHEMA = {
    key1: {
        foo: 'foo',
        bar: 'bar'
    },
    key2: {
        $keep: true,
        test: 'test'
    }
};

let r = flat.flatten(SCHEMA, {
    check: (value) => {
        return !(value.$keep);
    }
});

console.log(JSON.stringify(r, null, 2));
```

Will print:

```
{
  "key1.foo": "foo",
  "key1.bar": "bar",
  "key2": {
    "$keep": true,
    "test": "test"
  }
}
```

I'm using it in my schema validator.