### PR TITLE
Adding support for bracket notation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ unflatten({
 ### delimiter
 
 Use a custom delimiter for (un)flattening your objects, instead of `.`.
+To use bracket notation set the delimiter option to `[]`,`{}`, or `()`.
 
 ### safe
 

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function flatten(target, opts) {
       )
 
       var newKey = prev
-        ? prev + delimiter + key
+        ? prev + delimit(delimiter, key)
         : key
 
       if (!opts.maxDepth) {
@@ -68,7 +68,7 @@ function unflatten(target, opts) {
   }
 
   Object.keys(target).forEach(function(key) {
-    var split = key.split(delimiter)
+    var split = splitkey(key, delimiter)
     var key1 = getkey(split.shift())
     var key2 = getkey(split[0])
     var recipient = result
@@ -105,3 +105,35 @@ function isBuffer(value) {
   if (typeof Buffer === 'undefined') return false
   return Buffer.isBuffer(value)
 }
+
+// add delimiters to a key
+// 1-2 characters
+// 2 characters will be treated as brackets 
+// ex. delimit('[]', 'hi') = '[hi]'
+function delimit(delimiter, key) {
+  if (delimiter.length == 1) {
+    return delimiter + key
+  }
+  else {
+    var delimiters = delimiter.split('')
+    return delimiters[0] + key + delimiters[1]
+  }
+}
+
+// split a key by a delimiter(s)
+// 1 or 2 characters
+// 2 characters treated as brackets
+function splitkey(key, delimiter){
+  if (delimiter.length == 1) {
+    return key.split(delimiter)
+  }
+  else if (delimiter.length == 2) {
+    var delimiters = delimiter.split('')
+    var regex = new RegExp('\\'+delimiters[1] , 'g')
+    //remove trailing bracket from string
+    var result = key.replace(regex, '')
+    //split on leading bracket
+    return (result.split(delimiters[0]))
+  }
+}
+

--- a/test/test.js
+++ b/test/test.js
@@ -103,6 +103,22 @@ suite('Flatten', function() {
     })
   })
 
+  test('Custom Two Character Delimiter', function() {
+    assert.deepEqual(flatten({
+      hello: {
+        world: {
+          again: 'good morning'
+        }
+      }
+    }, {
+      delimiter: '()'
+    }), {
+      'hello(world)(again)': 'good morning'
+    })
+  })
+
+
+
   test('Empty Objects', function() {
     assert.deepEqual(flatten({
       hello: {
@@ -212,6 +228,20 @@ suite('Unflatten', function() {
       'hello world again': 'good morning'
     }, {
       delimiter: ' '
+    }))
+  })
+
+  test('Custom Two Character Delimiter', function() {
+    assert.deepEqual({
+      hello: {
+        world: {
+          again: 'good morning'
+        }
+      }
+    }, unflatten({
+      'hello[world][again]': 'good morning'
+    }, {
+      delimiter: '[]'
     }))
   })
 


### PR DESCRIPTION
I found this useful myself recently and thought others might as well.
```javascript
flatten({
     hello: {
       world: {
         again: 'good morning'
       }
     }
   }, {delimiter: '[]' })
//returns:  'hello[world][again]': 'good morning'

unflatten({'hello[world][again]': 'good morning'}, {delimiter: '[]' })
})

//returns:{hello: {world: {again: 'good morning'}}}
```