### PR TITLE
Use is-buffer to detect buffers without the Buffer module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+var isBuffer = require('is-buffer')
+
 var flat = module.exports = flatten
 flatten.flatten = flatten
 flatten.unflatten = unflatten
@@ -99,9 +101,4 @@ function unflatten(target, opts) {
   })
 
   return result
-}
-
-function isBuffer(value) {
-  if (typeof Buffer === 'undefined') return false
-  return Buffer.isBuffer(value)
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   "directories": {
     "test": "test"
   },
-  "dependencies": {},
+  "dependencies": {
+    "is-buffer": "~1.1.0"
+  },
   "repository": {
     "type": "git",
     "url": "git://github.com/hughsk/flat.git"


### PR DESCRIPTION
This cuts the browserified/min+gzip size of flat from ~7k to 750B. If you'd prefer I inline this instead of using a dep I'm happy to make that change.