### PR TITLE
don't do Number on key when object=true

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,6 +58,10 @@ function unflatten(target, opts) {
   // safely ensure that the key is
   // an integer.
   function getkey(key) {
+    if (opts.object) {
+      return key;
+    }
+
     var parsedKey = Number(key)
 
     return (


### PR DESCRIPTION
Following example:

```
unflatten(flat({
    'jazda': {
        '0000001': {'q': 1}
    }
}), {
    object: true
});
```

Outputs this:
`{ jazda: { '1': { q: 1 } } }`

But is expected to outputs this:
`{ jazda: { '0000001': { q: 1 } } }`

My patch makes flat works as expected in above example.
What do you think? Can it get merged?

Thanks.
