### PR TITLE
Add option to filter values that should be skipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,3 +158,27 @@ flatten({
 //   'key3.a': { b: { c: 2 } }
 // }
 ```
+
+### filter
+
+Decide if a value should be flattened any further
+
+```javascript
+var flatten = require('flat')
+
+flatten({
+    key1: {
+        keyA: 'valueI'
+    },
+    key2: {
+        keyB: 'valueII'
+    }
+}, { filter: (value) => !value.keyA }) // skip key1
+
+// {
+//   key1: {
+//       keyA: 'valueI'
+//   },
+//   'key2.keyB': 'valueII'
+// }
+```

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ function flatten(target, opts) {
 
   var delimiter = opts.delimiter || '.'
   var maxDepth = opts.maxDepth
+  var filter = opts.filter || function() { return true }
   var currentDepth = 1
   var output = {}
 
@@ -31,7 +32,7 @@ function flatten(target, opts) {
         maxDepth = currentDepth + 1;
       }
 
-      if (!isarray && !isbuffer && isobject && Object.keys(value).length && currentDepth < maxDepth) {
+      if (!isarray && !isbuffer && isobject && Object.keys(value).length && currentDepth < maxDepth && filter(value)) {
         ++currentDepth
         return step(value, newKey)
       }

--- a/test/test.js
+++ b/test/test.js
@@ -284,6 +284,56 @@ suite('Unflatten', function() {
     })
   })
 
+  suite('.filter', function() {
+    var everything = function() { return false }
+    var nothing = function() { return true }
+    var ifHasName = function(obj) { return !obj.name }
+
+    test('Should let a custom check decide if object should be flattened', function () {
+      var fixture = {
+        hello: {
+          world: 'hello',
+          good: {
+            bye: 'my friend'
+          },
+          something: {
+            nested: {
+              pretty: {
+                deep: true
+              },
+              name: 'hello'
+            }
+          },
+          array: ['of', 'values']
+        }
+      }
+
+      assert.deepEqual(flat(fixture, { filter: everything }), fixture)
+
+      assert.deepEqual(flat(fixture, { filter: nothing }), {
+        'hello.world': 'hello',
+        'hello.good.bye': 'my friend',
+        'hello.something.nested.pretty.deep': true,
+        'hello.something.nested.name': 'hello',
+        'hello.array.0': 'of',
+        'hello.array.1': 'values'
+      })
+
+      assert.deepEqual(flat(fixture, { filter: ifHasName }), {
+        'hello.world': 'hello',
+        'hello.good.bye': 'my friend',
+        'hello.something.nested': {
+          pretty: {
+            deep: true
+          },
+          name: 'hello'
+        },
+        'hello.array.0': 'of',
+        'hello.array.1': 'values'
+      })
+    })
+  })
+
   suite('.safe', function() {
     test('Should protect arrays when true', function() {
       assert.deepEqual(flatten({


### PR DESCRIPTION
I have a use case where I'm using flat on data that has 'meta' objects as leafs. With a filter function, I could tell flat to ignore these meta-leafs, no matter how deep they're nested.