### PR TITLE
let unflatten iterate over sorted object keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,14 +70,7 @@ function unflatten(target, opts) {
   }
 
   var sortedKeys = Object.keys(target).sort(function(keyA, keyB) {
-    var diff = keyA.length - keyB.length
-    if (diff < 0) {
-      return -1
-    } else if (diff > 0) {
-      return 1
-    } else {
-      return 0
-    }
+    return keyA.length - keyB.length
   })
 
   sortedKeys.forEach(function(key) {

--- a/index.js
+++ b/index.js
@@ -69,7 +69,18 @@ function unflatten(target, opts) {
       : parsedKey
   }
 
-  Object.keys(target).forEach(function(key) {
+  var sortedKeys = Object.keys(target).sort(function(keyA, keyB) {
+    var diff = keyA.length - keyB.length
+    if (diff < 0) {
+      return -1
+    } else if (diff > 0) {
+      return 1
+    } else {
+      return 0
+    }
+  })
+
+  sortedKeys.forEach(function(key) {
     var split = key.split(delimiter)
     var key1 = getkey(split.shift())
     var key2 = getkey(split[0])

--- a/test/test.js
+++ b/test/test.js
@@ -188,6 +188,7 @@ suite('Unflatten', function() {
         }
       },
       world: {
+        greet: 'hello',
         lorem: {
           ipsum: 'again',
           dolor: 'sit'
@@ -197,7 +198,8 @@ suite('Unflatten', function() {
       'hello.lorem.ipsum': 'again',
       'hello.lorem.dolor': 'sit',
       'world.lorem.ipsum': 'again',
-      'world.lorem.dolor': 'sit'
+      'world.lorem.dolor': 'sit',
+      'world': {greet: 'hello'}
     }))
   })
 


### PR DESCRIPTION
fixes #43 

sorting the object keys by length ensures that lower level objects are created first. 
without this PR an empty object is created (and never replaced/extended later) thus dropping parts of the object tree.
