### PR TITLE
Add toLowerCase and to toUpperCase options for flatten method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ unflatten({
 
 Use a custom delimiter for (un)flattening your objects, instead of `.`.
 
+### toUpperCase
+
+Use a toUpperCase option for flattening your objects and upper case object keys at the same time.
+This can be handy when working with constants, i.e. `API_KEY: 'some key'`
+
+### toLowerCase
+
+Use a toLowerCase option for flattening your objects and lower case object keys at the same time.
+
 ### safe
 
 When enabled, both `flat` and `unflatten` will preserve arrays and their

--- a/index.js
+++ b/index.js
@@ -8,6 +8,8 @@ function flatten(target, opts) {
   opts = opts || {}
 
   var delimiter = opts.delimiter || '.'
+  var lowerCase = opts.toLowerCase || false
+  var upperCase = opts.toUpperCase || false
   var maxDepth = opts.maxDepth
   var currentDepth = 1
   var output = {}
@@ -36,6 +38,12 @@ function flatten(target, opts) {
         return step(value, newKey)
       }
 
+      if (lowerCase) {
+        newKey = newKey.toLowerCase()
+      }
+      if (upperCase) {
+        newKey = newKey.toUpperCase()
+      }
       output[newKey] = value
     })
   }

--- a/test/test.js
+++ b/test/test.js
@@ -103,6 +103,34 @@ suite('Flatten', function() {
     })
   })
 
+  test('To upper case', function() {
+    assert.deepEqual(flatten({
+      hello: {
+        world: {
+          again: 'good morning'
+        }
+      }
+    }, {
+      toUpperCase: true
+    }), {
+      'HELLO.WORLD.AGAIN': 'good morning'
+    })
+  }) 
+
+  test('To lower case', function() {
+    assert.deepEqual(flatten({
+      HELLO: {
+        WORLD: {
+          AGAIN: 'good morning'
+        }
+      }
+    }, {
+      toLowerCase: true
+    }), {
+      'hello.world.again': 'good morning'
+    })
+  })
+
   test('Empty Objects', function() {
     assert.deepEqual(flatten({
       hello: {


### PR DESCRIPTION
It can come handy for environment constants, i.e API_KEY: 'some value'