### PR TITLE
Make flatten & unflatten reversible with safe option

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,9 @@ function unflatten(target, opts) {
     }
 
     // unflatten again for 'messy objects'
-    recipient[key1] = unflatten(target[key], opts)
+    if (!opts.safe) {
+      recipient[key1] = unflatten(target[key], opts)
+    }
   })
 
   return result


### PR DESCRIPTION
Flatten & Unflatten are not reversible for now.

e.g. :

```js
let test = {
  a: {
    b: 'c.d'
 }
}

let flatTest = flat.flatten(test);
// {
//   a.b: 'c.d'
// }

let unflatTest = flat.unflatten(flatTest);
// {
//   a: {
//     b: {
//       c: 'd'
//     }
//  }
// }
```

At least now with the safe option, this will be reversible.

```js
let test = {
  a: {
    b: 'c.d'
 }
}

let flatTest = flat.flatten(test);
// {
//   a.b: 'c.d'
// }

let unflatTest = flat.unflatten(flatTest, { safe: true });
// {
//   a: {
//     b: 'c.d'
//  }
// }
```

But to me the treatment of the messy object should be the optional behavior.
I propose the safe option just to avoid breaking the current API...