### PR TITLE
Add useToJSON option

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ function flatten (target, opts) {
 
   var delimiter = opts.delimiter || '.'
   var maxDepth = opts.maxDepth
+  var useToJSON = opts.useToJSON
   var output = {}
 
   function step (object, prev, currentDepth) {
@@ -23,16 +24,26 @@ function flatten (target, opts) {
         type === '[object Array]'
       )
 
+      var toJSONExists = false
+      var jsonValue = null
+      if (useToJSON && value === Object(value) && // Check if primitive type
+        Object.prototype.toString.call(value.toJSON) === '[object Function]') {
+        jsonValue = value.toJSON()
+        console.log('test ' + value.toJSON())
+        toJSONExists = true
+      }
+
       var newKey = prev
         ? prev + delimiter + key
         : key
 
-      if (!isarray && !isbuffer && isobject && Object.keys(value).length &&
+      if (!isarray && !isbuffer && isobject && !toJSONExists &&
+        Object.keys(value).length &&
         (!opts.maxDepth || currentDepth < maxDepth)) {
         return step(value, newKey, currentDepth + 1)
       }
 
-      output[newKey] = value
+      output[newKey] = toJSONExists ? jsonValue : value
     })
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -180,6 +180,29 @@ suite('Flatten', function () {
       'hello.0500': 'darkness my old friend'
     })
   })
+
+  test('Use useToJSON', function () {
+    assert.deepEqual(flatten({
+      hello: {
+        world: {
+          again: 'good morning',
+          toJSON: function () {
+            return 'good afternoon'
+          }
+        }
+      },
+      lorem: {
+        ipsum: {
+          dolor: 'good evening'
+        }
+      }
+    }, {
+      useToJSON: true
+    }), {
+      'hello.world': 'good afternoon',
+      'lorem.ipsum.dolor': 'good evening'
+    })
+  })
 })
 
 suite('Unflatten', function () {


### PR DESCRIPTION
This pull request add a new option to the library to force using the `toJSON` method of objects when it exits and it's the element is not a primitive (so it doesn't affect Dates). This allow to correctly flatten object as they would be if it was stringified to a JSON object using `JSON.stringify`. (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify)

This PR fixes an issue in a downstream library that I'm having at the moment, related to mongodb's ObjectIDs being incorrectly flattened (https://github.com/zemirco/json2csv/issues/175). However, I don't think that it's an isolated case. I believe it's a case common enough to have this extra option.

The PR contains unit test coverage for the change. Please let me know if everything is ok or if I need to do anything else.