### PR TITLE
feat: add command line interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,3 +158,30 @@ flatten({
 //   'key3.a': { b: { c: 2 } }
 // }
 ```
+
+## Command Line Usage
+
+`flat` is also available as a command line tool. You can run it with 
+[`npx`](https://ghub.io/npx):
+
+```sh
+npx flat foo.json
+```
+
+Or install the `flat` command globally:
+ 
+```sh
+npm i -g flat && flat foo.json
+```
+
+Accepts a filename as an argument:
+
+```sh
+flat foo.json
+```
+
+Also accepts JSON on stdin:
+
+```sh
+cat foo.json | flat
+```

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+const flat = require('.')
+const fs = require('fs')
+const readline = require('readline')
+
+if (process.stdin.isTTY) {
+  // Read from file
+  const file = process.argv.slice(2)[0]
+  if (!file) usage()
+  if (!fs.existsSync(file)) usage()
+  out(require(file))
+} else {
+  // Read from newline-delimited STDIN
+  const lines = []
+  readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    terminal: false
+  })
+    .on('line', line => lines.push(line))
+    .on('close', () => out(JSON.parse(lines.join('\n'))))
+}
+
+function out (data) {
+  process.stdout.write(JSON.stringify(flat(data), null, 2))
+}
+
+function usage () {
+  console.log(`
+Usage:
+
+flat foo.json
+cat foo.json | flat
+`)
+
+  process.exit()
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "flat",
   "version": "4.0.0",
   "main": "index.js",
+  "bin": "cli.js",
   "scripts": {
     "test": "mocha -u tdd --reporter spec && standard index.js test/index.js"
   },


### PR DESCRIPTION
This pull request adds a CLI to `flat`.

```
Usage:

flat foo.json
cat foo.json | flat
```

Resolves #71 