### PR TITLE
Implemented delimiter as callback function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/README.md
+++ b/README.md
@@ -66,6 +66,29 @@ unflatten({
 
 Use a custom delimiter for (un)flattening your objects, instead of `.`.
 
+For total control over the key use a callback function as a delimiter.
+
+``` javascript
+
+/**
+ * @param {string} key - a property of an iterated object
+ * @param {string|undefined} prev - the string accumulating all the properties. Undefined for the first object
+ * @return {string}
+ */
+function delimiter(key, prev){
+  return prev ? prev + "[" + key + "]" : key
+}
+flatten({
+    hello: {
+      world: {
+        again: 'good morning'
+      }
+    }
+}, {
+  delimiter: delimiter
+}) //  resulting {'hello[world][again]': 'good morning'}
+```
+
 ### safe
 
 When enabled, both `flat` and `unflatten` will preserve arrays and their

--- a/index.js
+++ b/index.js
@@ -23,9 +23,12 @@ function flatten (target, opts) {
         type === '[object Array]'
       )
 
-      var newKey = prev
-        ? prev + delimiter + key
-        : key
+      var newKey
+      if (delimiter instanceof Function) {
+        newKey = prev ? prev + delimiter(key) : key
+      } else {
+        newKey = prev ? prev + delimiter + key : key
+      }
 
       if (!isarray && !isbuffer && isobject && Object.keys(value).length &&
         (!opts.maxDepth || currentDepth < maxDepth)) {
@@ -71,7 +74,7 @@ function unflatten (target, opts) {
   })
 
   sortedKeys.forEach(function (key) {
-    var split = key.split(delimiter)
+    var split = delimiter instanceof Function ? delimiter(key) : key.split(delimiter)
     var key1 = getkey(split.shift())
     var key2 = getkey(split[0])
     var recipient = result

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function flatten (target, opts) {
 
       var newKey
       if (delimiter instanceof Function) {
-        newKey = prev ? prev + delimiter(key) : key
+        newKey = delimiter(key, prev)
       } else {
         newKey = prev ? prev + delimiter + key : key
       }

--- a/test/test.js
+++ b/test/test.js
@@ -113,8 +113,8 @@ suite('Flatten', function () {
         }
       }
     }, {
-      delimiter: function(key){
-        return ":" + key
+      delimiter: function(key, prev){
+         return prev ? prev + ':' + key : key
       }
     }), {
       'hello:world:again': 'good morning'
@@ -129,8 +129,8 @@ suite('Flatten', function () {
         }
       }
     }, {
-      delimiter: function(key){
-        return "[" + key + "]"
+      delimiter: function(key, prev){
+        return prev ? prev + "[" + key + "]" : key
       }
     }), {
       'hello[world][again]': 'good morning'

--- a/test/test.js
+++ b/test/test.js
@@ -105,6 +105,38 @@ suite('Flatten', function () {
     })
   })
 
+  test('Callback Delimiter', function() {
+    assert.deepEqual(flatten({
+      hello: {
+        world: {
+          again: 'good morning'
+        }
+      }
+    }, {
+      delimiter: function(key){
+        return ":" + key
+      }
+    }), {
+      'hello:world:again': 'good morning'
+    })
+  })
+
+  test('Delimiter for url query', function() {
+    assert.deepEqual(flatten({
+      hello: {
+        world: {
+          again: 'good morning'
+        }
+      }
+    }, {
+      delimiter: function(key){
+        return "[" + key + "]"
+      }
+    }), {
+      'hello[world][again]': 'good morning'
+    })
+  })
+
   test('Empty Objects', function () {
     assert.deepEqual(flatten({
       hello: {
@@ -254,6 +286,40 @@ suite('Unflatten', function () {
       'hello world again': 'good morning'
     }, {
       delimiter: ' '
+    }))
+  })
+
+  test('Callback Delimiter', function() {
+    assert.deepEqual({
+      hello: {
+        world: {
+          again: 'good morning'
+        }
+      }
+    }, unflatten({
+      'hello:world:again': 'good morning'
+    }, {
+      delimiter: function(key){
+        return key.split(':')
+      }
+    }))
+  })
+
+  test('Delimiter for url query', function() {
+    assert.deepEqual({
+      hello: {
+        world: {
+          again: 'good morning'
+        }
+      }
+    }, unflatten({
+      'hello[world][again]': 'good morning'
+    }, {
+      delimiter: function(key){
+        var steps = key.split(/(?:]\[)|\[|]$/)
+        steps.pop() // last empty string
+        return steps
+      }
     }))
   })
 
@@ -511,3 +577,4 @@ suite('Arrays', function () {
     })
   })
 })
+

--- a/test/test.js
+++ b/test/test.js
@@ -125,7 +125,8 @@ suite('Flatten', function () {
     assert.deepEqual(flatten({
       hello: {
         world: {
-          again: 'good morning'
+          again: 'good morning',
+          never: 'give up'
         }
       }
     }, {
@@ -133,7 +134,8 @@ suite('Flatten', function () {
         return prev ? prev + "[" + key + "]" : key
       }
     }), {
-      'hello[world][again]': 'good morning'
+      'hello[world][again]': 'good morning',
+      'hello[world][never]': 'give up'
     })
   })
 


### PR DESCRIPTION
To provide more flexibility and cover more use cases the delimiter is improved to support a callback function. E.g. ```flatten``` might be used to convert a nested object into a ```UrlSearchParams``` or ```FormData```. 

```
    flatten({
      hello: {
        world: {
          again: 'good morning',
          never: 'give up'
        }
      }
    }, {
      delimiter: function(key, prev){
        return prev ? prev + "[" + key + "]" : key
      }
    }) //  resulting {'hello[world][again]': 'good morning'}
```