### PR TITLE
 Remove dependency on is-buffer 

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
-var isBuffer = require('is-buffer')
+function isBuffer(val) {
+  return ![, null].includes(val) && val.constructor === Buffer;
+}
 
 module.exports = flatten
 flatten.flatten = flatten

--- a/package.json
+++ b/package.json
@@ -15,9 +15,6 @@
   "directories": {
     "test": "test"
   },
-  "dependencies": {
-    "is-buffer": "~2.0.3"
-  },
   "repository": {
     "type": "git",
     "url": "git://github.com/hughsk/flat.git"


### PR DESCRIPTION
As the function was used only once, I inlined it in the code and removed the dependency on `is-buffer` from `package.json`. Your package is now dependency-free!