### PR TITLE
Unflatten dot-notation keys nested in an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,7 @@ Use a custom delimiter for (un)flattening your objects, instead of `.`.
 
 ### safe
 
-When enabled, both `flat` and `unflatten` will preserve arrays and their
-contents. This is disabled by default.
+When enabled `flatten` will preserve arrays and their contents. This is disabled by default.
 
 ``` javascript
 var flatten = require('flat')

--- a/index.js
+++ b/index.js
@@ -49,7 +49,11 @@ function unflatten (target, opts) {
   var result = {}
 
   var isbuffer = isBuffer(target)
-  if (isbuffer || Object.prototype.toString.call(target) !== '[object Object]') {
+  if (Array.isArray(target)) {
+    return target.map(function (item) {
+      return unflatten(item, opts)
+    })
+  } else if (isbuffer || Object.prototype.toString.call(target) !== '[object Object]') {
     return target
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -180,6 +180,46 @@ suite('Flatten', function () {
       'hello.0500': 'darkness my old friend'
     })
   })
+
+  suite('.safe', function () {
+    test('Should not protect arrays when false', function () {
+      assert.deepEqual(flatten({
+        hello: [
+          { world: { again: 'foo' } },
+          { lorem: 'ipsum' }
+        ]
+      }, {
+        safe: false
+      }), {
+        'hello.0.world.again': 'foo',
+        'hello.1.lorem': 'ipsum'
+      })
+    })
+
+    test('Should protect arrays when true', function () {
+      assert.deepEqual(flatten({
+        hello: [
+          { world: { again: 'foo' } },
+          { lorem: 'ipsum' }
+        ],
+        another: {
+          nested: [{ array: { too: 'deep' } }]
+        },
+        lorem: {
+          ipsum: 'whoop'
+        }
+      }, {
+        safe: true
+      }), {
+        hello: [
+          { world: { again: 'foo' } },
+          { lorem: 'ipsum' }
+        ],
+        'lorem.ipsum': 'whoop',
+        'another.nested': [{ array: { too: 'deep' } }]
+      })
+    })
+  })
 })
 
 suite('Unflatten', function () {
@@ -323,46 +363,6 @@ suite('Unflatten', function () {
       assert.deepEqual(flat.unflatten({ a: 0, 'a.b': 'c' }), { a: 0 })
       assert.deepEqual(flat.unflatten({ a: 1, 'a.b': 'c' }), { a: 1 })
       assert.deepEqual(flat.unflatten({ a: '', 'a.b': 'c' }), { a: '' })
-    })
-  })
-
-  suite('.safe', function () {
-    test('Should protect arrays when true', function () {
-      assert.deepEqual(flatten({
-        hello: [
-            { world: { again: 'foo' } },
-           { lorem: 'ipsum' }
-        ],
-        another: {
-          nested: [{ array: { too: 'deep' } }]
-        },
-        lorem: {
-          ipsum: 'whoop'
-        }
-      }, {
-        safe: true
-      }), {
-        hello: [
-            { world: { again: 'foo' } },
-           { lorem: 'ipsum' }
-        ],
-        'lorem.ipsum': 'whoop',
-        'another.nested': [{ array: { too: 'deep' } }]
-      })
-    })
-
-    test('Should not protect arrays when false', function () {
-      assert.deepEqual(flatten({
-        hello: [
-            { world: { again: 'foo' } },
-           { lorem: 'ipsum' }
-        ]
-      }, {
-        safe: false
-      }), {
-        'hello.0.world.again': 'foo',
-        'hello.1.lorem': 'ipsum'
-      })
     })
   })
 

--- a/test/test.js
+++ b/test/test.js
@@ -366,6 +366,22 @@ suite('Unflatten', function () {
     })
   })
 
+  suite('.safe', function () {
+    test('Should unflatten dot notation keys nested in array', function () {
+      assert.deepEqual(unflatten({
+        hello: [
+          { 'something.nested': true }
+        ]
+      }, {
+        safe: false
+      }), {
+        hello: [
+          { something: { nested: true } }
+        ]
+      })
+    })
+  })
+
   suite('.object', function () {
     test('Should create object instead of array when true', function () {
       var unflattened = unflatten({


### PR DESCRIPTION
 There are two things in this PR:
* Readme correction. The `unflatten()` function does not actually support the `safe` option.
* The `unflatten()` function previously did not support unflattening keys nested in an array. It does now.

```javascript
// before: array is totally ignored
unflatten({ this: [ { 'lorem.ipsum': 'bar' } ] })
// => { this: [ { 'lorem.ipsum': 'bar' } ] }

// after: objects in array are unflattened
unflatten({ this: [ { 'lorem.ipsum': 'bar' } ] })
// => { this: [ { lorem: { ipsum: 'bar' } } ] }

```