### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,9 +66,7 @@ function unflatten (target, opts) {
       : parsedKey
   }
 
-  var sortedKeys = Object.keys(target).sort(function (keyA, keyB) {
-    return keyA.length - keyB.length
-  })
+  var sortedKeys = Object.keys(target).sort();
 
   sortedKeys.forEach(function (key) {
     var split = key.split(delimiter)


### PR DESCRIPTION
Hi,

This achieves the same thing as https://github.com/hughsk/flat/issues/43 but doesn't put the keys in a weird order (by length), instead it does a lexical sort (i.e. 0-1 A-Z)

```js
['world.lorem.ipsum',
'apple.zebra',
'apple',
'apple.aa',
'world.lorem.dolor',
'0test',
'world'].sort()
```

Becomes:

```
["0test", "apple", "apple.aa", "apple.zebra", "world", "world.lorem.dolor", "world.lorem.ipsum"]
```

Rather than:

```
['world.lorem.ipsum',
'apple.zebra',
'apple',
'apple.aa',
'world.lorem.dolor',
'0test',
'world'].sort(function(keyA, keyB) {
    return keyA.length - keyB.length
  })

["apple", "0test", "world", "apple.aa", "apple.zebra", "world.lorem.ipsum", "world.lorem.dolor"]
```