### PR TITLE
Losing an order of keys after unflatten an object

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,6 @@ function unflatten (target, opts) {
       result[key] = target[key]
       return result
     } else {
-      console.log(target[key])
       return addKeys(
         key,
         result,

--- a/package.json
+++ b/package.json
@@ -9,14 +9,14 @@
   "license": "BSD-3-Clause",
   "description": "Take a nested Javascript object and flatten it, or unflatten an object with delimited keys",
   "devDependencies": {
-    "mocha": "~3.4.2",
-    "standard": "^10.0.2"
+    "mocha": "~5.2.0",
+    "standard": "^11.0.1"
   },
   "directories": {
     "test": "test"
   },
   "dependencies": {
-    "is-buffer": "~1.1.5"
+    "is-buffer": "~2.0.3"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flat",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "main": "index.js",
   "bin": "cli.js",
   "scripts": {


### PR DESCRIPTION
This PR fixes an order of keys in an object. Mentioned in issue #43 
I make all objects and arrays to flat before it is unflattened. It fixes both issues keeping the order and adding objects and arrays in a flattened object.