### PR TITLE
drop dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,13 @@
-var isBuffer = require('is-buffer')
-
 module.exports = flatten
 flatten.flatten = flatten
 flatten.unflatten = unflatten
+
+function isBuffer (obj) {
+  return obj &&
+    obj.constructor &&
+    (typeof obj.constructor.isBuffer === 'function') &&
+    obj.constructor.isBuffer(obj);
+}
 
 function keyIdentity (key) {
   return key

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ function isBuffer (obj) {
   return obj &&
     obj.constructor &&
     (typeof obj.constructor.isBuffer === 'function') &&
-    obj.constructor.isBuffer(obj);
+    obj.constructor.isBuffer(obj)
 }
 
 function keyIdentity (key) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1018,7 +1018,8 @@
     "is-buffer": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+      "dev": true
     },
     "is-callable": {
       "version": "1.1.4",

--- a/package.json
+++ b/package.json
@@ -15,9 +15,7 @@
   "directories": {
     "test": "test"
   },
-  "dependencies": {
-    "is-buffer": "~2.0.4"
-  },
+  "dependencies": {},
   "repository": {
     "type": "git",
     "url": "git://github.com/hughsk/flat.git"


### PR DESCRIPTION
Something as fundamental and easy as checking if an object is a buffer shouldn't need a micro-dependency.

This way your package has no dependencies.