### PR TITLE
Fix prototype pollution in unflatten

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,6 +116,10 @@ function unflatten (target, opts) {
     let recipient = result
 
     while (key2 !== undefined) {
+      if (key1 === '__proto__') {
+        return
+      }
+
       const type = Object.prototype.toString.call(recipient[key1])
       const isobject = (
         type === '[object Object]' ||

--- a/test/test.js
+++ b/test/test.js
@@ -531,6 +531,20 @@ suite('Unflatten', function () {
       })
     })
   }
+
+  test('should not pollute prototype', function () {
+      unflatten({
+          '__proto__.polluted': true
+      });
+      unflatten({
+          'prefix.__proto__.polluted': true
+      });
+      unflatten({
+          'prefix.0.__proto__.polluted': true
+      });
+
+      assert.notStrictEqual({}.polluted, true);
+  })
 })
 
 suite('Arrays', function () {


### PR DESCRIPTION
The `unflatten` function contains a [prototype pollution](https://github.com/Kirill89/prototype-pollution-explained) vulnerability. I've added a test and fix.

I've tested back to 1.0.0 and all versions are vulnerable.

This fixes #105 .