### PR TITLE
Add arrayBrackets option

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,30 @@ unflatten({
 // }
 ```
 
+### arrayBrackets
+
+When enabled, array children will be wrapped in brackets:
+
+``` javascript
+flatten({
+    arr: [
+        'a',
+        'b'
+    ],
+    arr2: [
+        {
+            keyB: 'valueII'
+        }
+    ]
+}, { arrayBrackets: true })
+
+// {
+//   'arr[0]': 'a',
+//   'arr[1]': 'b',
+//   'arr2[0].keyB': 'valueII'
+// }
+```
+
 ### overwrite
 
 When enabled, existing keys in the unflattened object may be overwritten if they cannot hold a newly encountered nested value:

--- a/index.js
+++ b/index.js
@@ -19,9 +19,10 @@ function flatten (target, opts) {
   const delimiter = opts.delimiter || '.'
   const maxDepth = opts.maxDepth
   const transformKey = opts.transformKey || keyIdentity
+  const arrayBrackets = opts.arrayBrackets || false
   const output = {}
 
-  function step (object, prev, currentDepth) {
+  function step (object, prev, currentDepth, addbrackets) {
     currentDepth = currentDepth || 1
     Object.keys(object).forEach(function (key) {
       const value = object[key]
@@ -32,14 +33,22 @@ function flatten (target, opts) {
         type === '[object Object]' ||
         type === '[object Array]'
       )
+      const childhasbrackets = arrayBrackets && Array.isArray(value)
 
-      const newKey = prev
-        ? prev + delimiter + transformKey(key)
-        : transformKey(key)
+      let newKey
+      if (addbrackets) {
+        newKey = prev
+          ? prev + '[' + transformKey(key) + ']'
+          : '[' + transformKey(key) + ']'
+      } else {
+        newKey = prev
+          ? prev + delimiter + transformKey(key)
+          : transformKey(key)
+      }
 
       if (!isarray && !isbuffer && isobject && Object.keys(value).length &&
         (!opts.maxDepth || currentDepth < maxDepth)) {
-        return step(value, newKey, currentDepth + 1)
+        return step(value, newKey, currentDepth + 1, childhasbrackets)
       }
 
       output[newKey] = value

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "flat",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -109,6 +109,26 @@ suite('Flatten', function () {
     })
   })
 
+  test('Array Brackets', function () {
+    assert.deepStrictEqual(flatten({
+      hello: [
+        {
+          world: {
+            again: 'good morning'
+          }
+        }
+      ],
+      arr: [1, 2, 3]
+    }, {
+      arrayBrackets: true
+    }), {
+      'hello[0].world.again': 'good morning',
+      'arr[0]': 1,
+      'arr[1]': 2,
+      'arr[2]': 3
+    })
+  })
+
   test('Empty Objects', function () {
     assert.deepStrictEqual(flatten({
       hello: {


### PR DESCRIPTION
Hi all!

So, not sure if this is welcome or not, but I thought I'd give it a shot. I noticed a lot of issues where people were wanting some way to support the syntax of lodash's set/get, among other tools. I created an option, `arrayBrackets`, that wraps array indexes in brackets and omits the delimiter. I'm happy to make any changes, please let me know.