### PR TITLE
Fix issue #127 in unflatten method

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,7 +130,12 @@ function unflatten (target, opts) {
         type === '[object Object]' ||
         type === '[object Array]'
       )
-
+      
+      // if is a prototype key assign undefined value
+      if (typeof recipient[key1] === 'function') {
+        recipient[key1] = undefined;
+      }
+      
       // do not write over falsey, non-undefined values if overwrite is false
       if (!overwrite && !isobject && typeof recipient[key1] !== 'undefined') {
         return

--- a/test/test.js
+++ b/test/test.js
@@ -610,6 +610,32 @@ suite('Order of Keys', function () {
   })
 })
 
+suite('Object Prototype Keys', function () {
+  test('Should be able to unflatten object prototype keys (constructor, toString, valueOf, etc.)', function () {
+    assert.deepStrictEqual({
+      a: {
+        constructor: {
+          constructor: 'hello'
+        }
+      },
+      b: {
+        toString: {
+          toString: 'hello'
+        }
+      },
+      c: {
+        valueOf: {
+          valueOf: 'hello'
+        }
+      }
+    }, unflatten({
+      'a.constructor.constructor': 'hello',
+      'b.toString.toString': 'hello',
+      'c.valueOf.valueOf': 'hello',
+    }))
+  })
+})
+
 suite('CLI', function () {
   test('can take filename', function (done) {
     const cli = path.resolve(__dirname, '..', pkg.bin)


### PR DESCRIPTION
Fix issue #127: in unflatten method when the key is an object prototype key name like constructor, toString, valueOf, etc. the unflatten method is returning an empty object