### PR TITLE
Add TypeScript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,39 @@
+// Definitions by:  Ilya Mochalov <https://github.com/chrootsu>
+//                  Oz Weiss <https://github.com/thewizarodofoz>
+
+declare var flatten: FlatTypes.Flatten;
+
+export = flatten;
+
+declare namespace FlatTypes {
+    interface FlattenOptions {
+        delimiter?: string | undefined;
+        safe?: boolean | undefined;
+        maxDepth?: number | undefined;
+        transformKey?: ((key: string) => string) | undefined;
+    }
+
+    interface Flatten {
+        <TTarget, TResult>(
+            target: TTarget,
+            options?: FlattenOptions
+        ): TResult;
+
+        flatten: Flatten;
+        unflatten: Unflatten;
+    }
+
+    interface UnflattenOptions {
+        delimiter?: string | undefined;
+        object?: boolean | undefined;
+        overwrite?: boolean | undefined;
+        transformKey?: ((key: string) => string) | undefined;
+    }
+
+    interface Unflatten {
+        <TTarget, TResult>(
+            target: TTarget,
+            options?: UnflattenOptions
+        ): TResult;
+    }
+}


### PR DESCRIPTION
Adds the TypeScript definitions from [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/flat/index.d.ts) to the package. This enhances the out-of-the box experience for TypeScript users as they no longer have to manually install `@types/flat`. This change is also useful for non-TypeScript users it allows their IDE to give them auto-completion of the API offered by flat.