### PR TITLE
Use new URL for 'author' field

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "object",
     "nested"
   ],
-  "author": "Hugh Kennedy <hughskennedy@gmail.com> (http://hughskennedy.com)",
+  "author": "Hugh Kennedy <hughskennedy@gmail.com> (https://hughsk.io)",
   "bugs": {
     "url": "https://github.com/hughsk/flat/issues"
   },


### PR DESCRIPTION
The old URL for @hughsk's personal site is no longer active, so this replaces it with the correct one.