### PR TITLE
Convert code to ECMAScript modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Flattens the object - it'll return an object one level deep, regardless of how
 nested the original object was:
 
 ``` javascript
-var flatten = require('flat')
+import { flatten } from 'flat'
 
 flatten({
     key1: {
@@ -38,10 +38,10 @@ flatten({
 
 ### unflatten(original, options)
 
-Flattening is reversible too, you can call `flatten.unflatten()` on an object:
+Flattening is reversible too, you can call `unflatten` on an object:
 
 ``` javascript
-var unflatten = require('flat').unflatten
+import { unflatten } from 'flat'
 
 unflatten({
     'three.levels.deep': 42,
@@ -72,7 +72,7 @@ When enabled, both `flat` and `unflatten` will preserve arrays and their
 contents. This is disabled by default.
 
 ``` javascript
-var flatten = require('flat')
+import { flatten } from 'flat'
 
 flatten({
     this: [
@@ -140,7 +140,7 @@ This only makes sense on ordered arrays, and since we're overwriting data, shoul
 Maximum number of nested objects to flatten.
 
 ``` javascript
-var flatten = require('flat')
+import { flatten } from 'flat'
 
 flatten({
     key1: {
@@ -164,8 +164,7 @@ flatten({
 Transform each part of a flat key before and after flattening.
 
 ```javascript
-var flatten = require('flat')
-var unflatten = require('flat').unflatten
+import { flatten, unflatten } from 'flat'
 
 flatten({
     key1: {

--- a/cli.js
+++ b/cli.js
@@ -1,17 +1,15 @@
 #!/usr/bin/env node
-
-const fs = require('fs')
-const path = require('path')
-const readline = require('readline')
-
-const flat = require('./index')
+import fs from 'node:fs'
+import path from 'node:path'
+import readline from 'node:readline'
+import { flatten } from './index.js'
 
 const filepath = process.argv.slice(2)[0]
 if (filepath) {
   // Read from file
   const file = path.resolve(process.cwd(), filepath)
   fs.accessSync(file, fs.constants.R_OK) // allow to throw if not readable
-  out(require(file))
+  out(JSON.parse(fs.readFileSync(file)))
 } else if (process.stdin.isTTY) {
   usage(0)
 } else {
@@ -27,7 +25,7 @@ if (filepath) {
 }
 
 function out (data) {
-  process.stdout.write(JSON.stringify(flat(data), null, 2))
+  process.stdout.write(JSON.stringify(flatten(data), null, 2))
 }
 
 function usage (code) {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,3 @@
-module.exports = flatten
-flatten.flatten = flatten
-flatten.unflatten = unflatten
-
 function isBuffer (obj) {
   return obj &&
     obj.constructor &&
@@ -13,7 +9,7 @@ function keyIdentity (key) {
   return key
 }
 
-function flatten (target, opts) {
+export function flatten (target, opts) {
   opts = opts || {}
 
   const delimiter = opts.delimiter || '.'
@@ -51,7 +47,7 @@ function flatten (target, opts) {
   return output
 }
 
-function unflatten (target, opts) {
+export function unflatten (target, opts) {
   opts = opts || {}
 
   const delimiter = opts.delimiter || '.'

--- a/package.json
+++ b/package.json
@@ -1,9 +1,14 @@
 {
   "name": "flat",
   "version": "5.0.2",
+  "type": "module",
   "main": "index.js",
+  "exports": "./index.js",
   "bin": "cli.js",
   "sideEffects": false,
+  "engines": {
+    "node": ">=14.16"
+  },
   "scripts": {
     "test": "mocha -u tdd --reporter spec && standard cli.js index.js test/test.js"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -1,13 +1,13 @@
 /* globals suite test */
+import assert from 'node:assert'
+import { exec } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { flatten, unflatten } from '../index.js'
 
-const assert = require('assert')
-const path = require('path')
-const { exec } = require('child_process')
-const pkg = require('../package.json')
-const flat = require('../index')
-
-const flatten = flat.flatten
-const unflatten = flat.unflatten
+const __dirname = fileURLToPath(new URL('.', import.meta.url))
+const pkg = JSON.parse(readFileSync('./package.json'))
 
 const primitives = {
   String: 'good morning',
@@ -361,22 +361,22 @@ suite('Unflatten', function () {
 
   suite('Overwrite + non-object values in key positions', function () {
     test('non-object keys + overwrite should be overwritten', function () {
-      assert.deepStrictEqual(flat.unflatten({ a: null, 'a.b': 'c' }, { overwrite: true }), { a: { b: 'c' } })
-      assert.deepStrictEqual(flat.unflatten({ a: 0, 'a.b': 'c' }, { overwrite: true }), { a: { b: 'c' } })
-      assert.deepStrictEqual(flat.unflatten({ a: 1, 'a.b': 'c' }, { overwrite: true }), { a: { b: 'c' } })
-      assert.deepStrictEqual(flat.unflatten({ a: '', 'a.b': 'c' }, { overwrite: true }), { a: { b: 'c' } })
+      assert.deepStrictEqual(unflatten({ a: null, 'a.b': 'c' }, { overwrite: true }), { a: { b: 'c' } })
+      assert.deepStrictEqual(unflatten({ a: 0, 'a.b': 'c' }, { overwrite: true }), { a: { b: 'c' } })
+      assert.deepStrictEqual(unflatten({ a: 1, 'a.b': 'c' }, { overwrite: true }), { a: { b: 'c' } })
+      assert.deepStrictEqual(unflatten({ a: '', 'a.b': 'c' }, { overwrite: true }), { a: { b: 'c' } })
     })
 
     test('overwrite value should not affect undefined keys', function () {
-      assert.deepStrictEqual(flat.unflatten({ a: undefined, 'a.b': 'c' }, { overwrite: true }), { a: { b: 'c' } })
-      assert.deepStrictEqual(flat.unflatten({ a: undefined, 'a.b': 'c' }, { overwrite: false }), { a: { b: 'c' } })
+      assert.deepStrictEqual(unflatten({ a: undefined, 'a.b': 'c' }, { overwrite: true }), { a: { b: 'c' } })
+      assert.deepStrictEqual(unflatten({ a: undefined, 'a.b': 'c' }, { overwrite: false }), { a: { b: 'c' } })
     })
 
     test('if no overwrite, should ignore nested values under non-object key', function () {
-      assert.deepStrictEqual(flat.unflatten({ a: null, 'a.b': 'c' }), { a: null })
-      assert.deepStrictEqual(flat.unflatten({ a: 0, 'a.b': 'c' }), { a: 0 })
-      assert.deepStrictEqual(flat.unflatten({ a: 1, 'a.b': 'c' }), { a: 1 })
-      assert.deepStrictEqual(flat.unflatten({ a: '', 'a.b': 'c' }), { a: '' })
+      assert.deepStrictEqual(unflatten({ a: null, 'a.b': 'c' }), { a: null })
+      assert.deepStrictEqual(unflatten({ a: 0, 'a.b': 'c' }), { a: 0 })
+      assert.deepStrictEqual(unflatten({ a: 1, 'a.b': 'c' }), { a: 1 })
+      assert.deepStrictEqual(unflatten({ a: '', 'a.b': 'c' }), { a: '' })
     })
   })
 


### PR DESCRIPTION
Converts all code in the library to use ECMAScript modules instead of CommonJS. More information can be found [here](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c).