### PR TITLE
Replace link to NPX docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,8 +209,7 @@ unflatten({
 
 ## Command Line Usage
 
-`flat` is also available as a command line tool. You can run it with 
-[`npx`](https://ghub.io/npx):
+`flat` is also available as a command line tool. You can run it with [`npx`](https://docs.npmjs.com/cli/v8/commands/npx):
 
 ```sh
 npx flat foo.json


### PR DESCRIPTION
Replaces the link to the `npx` docs with the official one from NPM.