### PR TITLE
Remove 'directories' field from package

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,6 @@
     "mocha": "^10.0.0",
     "standard": "^17.0.0"
   },
-  "directories": {
-    "test": "test"
-  },
   "repository": {
     "type": "git",
     "url": "git://github.com/hughsk/flat.git"


### PR DESCRIPTION
Remove the [`directories`](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#directories) field from the package file, which is a CommonJS specific field.