### PR TITLE
Add 'files' field to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,11 @@
   "exports": "./index.js",
   "types": "./index.d.ts",
   "bin": "cli.js",
+  "files": [
+    "cli.js",
+    "index.js",
+    "index.d.ts"
+  ],
   "sideEffects": false,
   "engines": {
     "node": ">=14.16"


### PR DESCRIPTION
Adds the [`files`](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#files) field to the package file. This ensures we are only including the files we need in the final package uploaded to NPM.