### PR TITLE
Distinct array or object by keep a empty array literal

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,9 @@ export function flatten (target, opts) {
 
       if (!isarray && !isbuffer && isobject && Object.keys(value).length &&
         (!opts.maxDepth || currentDepth < maxDepth)) {
+        if (opts.useEmptyArray && Array.isArray(value)) {
+          output[newKey] = []
+        }
         return step(value, newKey, currentDepth + 1)
       }
 


### PR DESCRIPTION
The numeric keys is ambiguous, which could mean object keys or array indice.
If `flatten` function output a empty array for a array, it would be precise the numeric keys mean the array indice.

Eg: `{a: [1,2]}` is flatten to `{a: [], 'a.0': 1, 'a.1': 2}`,
and `{a: {'0': 1, '1': 2}}` is flatten to `{'a.0': 1, 'a.1': 2}`,
so we can distinct array and object.

A new option `useEmptyArray` will to turn on this feature.

This is similar to the `safe` option, but the values in array still get flatten.

The docs and the tests are not updated yet, and this seem to cause some side effects on flatten object while `unflatten`.
I will update them if hughsk is interested in merging this feature.

Somewhat relate to #74 .
