### PR TITLE
Add improved `exports` field to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,15 @@
   "name": "flat",
   "version": "6.0.0",
   "type": "module",
-  "main": "index.js",
-  "exports": "./index.js",
-  "types": "./index.d.ts",
   "bin": "cli.js",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.js"
+      }
+    }
+  },
   "files": [
     "cli.js",
     "index.js",


### PR DESCRIPTION
Completely moves the entry-points to the [`exports` field](https://nodejs.org/api/packages.html#exports). The expanded `exports` field allows more recent versions of TypeScript with the `Node16` preset to load the types properly. This allows it to pass the  [Are the types wrong? CLI](https://github.com/arethetypeswrong/arethetypeswrong.github.io/tree/main/packages/cli) and [`publint`](https://publint.dev/) (CommonJS checks aside).

Although the `main` and `type` field might still be used by some tooling I've left them out on purpose. If we get feedback from users this is still needed we can restore it in a patch release.