### PR TITLE
Raise minimum Node.js version to 18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [14, 16, 18]
+        node: [18, 20]
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "standard": "^17.0.0"
       },
       "engines": {
-        "node": ">=14.16"
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "sideEffects": false,
   "engines": {
-    "node": ">=14.16"
+    "node": ">=18"
   },
   "scripts": {
     "test": "mocha -u tdd --reporter spec && standard cli.js index.js test/test.js"


### PR DESCRIPTION
Raises the minimum Node.js version to 18, as version 14 and 16 are now end-of-life. See the [Node.js release schedule](https://github.com/nodejs/Release#release-schedule) for more information.