### PR TITLE
Apply NPM suggestions for `bin`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "flat",
   "version": "6.0.0",
   "type": "module",
-  "bin": "cli.js",
+  "bin": {
+    "flat": "cli.js"
+  },
   "exports": {
     ".": {
       "import": {

--- a/test/test.js
+++ b/test/test.js
@@ -612,7 +612,7 @@ suite('Order of Keys', function () {
 
 suite('CLI', function () {
   test('can take filename', function (done) {
-    const cli = path.resolve(__dirname, '..', pkg.bin)
+    const cli = path.resolve(__dirname, '..', pkg.bin.flat)
     const pkgJSON = path.resolve(__dirname, '..', 'package.json')
     exec(`${cli} ${pkgJSON}`, (err, stdout, stderr) => {
       assert.ifError(err)
@@ -622,7 +622,7 @@ suite('CLI', function () {
   })
 
   test('exits with usage if no file', function (done) {
-    const cli = path.resolve(__dirname, '..', pkg.bin)
+    const cli = path.resolve(__dirname, '..', pkg.bin.flat)
     const pkgJSON = path.resolve(__dirname, '..', 'package.json')
     exec(`${cli} ${pkgJSON}`, (err, stdout, stderr) => {
       assert.ifError(err)
@@ -632,7 +632,7 @@ suite('CLI', function () {
   })
 
   test('can take piped file', function (done) {
-    const cli = path.resolve(__dirname, '..', pkg.bin)
+    const cli = path.resolve(__dirname, '..', pkg.bin.flat)
     const pkgJSON = path.resolve(__dirname, '..', 'package.json')
     exec(`cat ${pkgJSON} | ${cli}`, (err, stdout, stderr) => {
       assert.ifError(err)


### PR DESCRIPTION
Converts the `bin` field in the package to an object. This a migration that NPM applies automatically when publishing:

![image](https://github.com/hughsk/flat/assets/695720/2464ce0c-eecc-44ea-9054-fbd63ffa6faa)
