### PR TITLE
fix: package.json `exports` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   },
   "exports": {
     ".": {
-        "types": "./index.d.ts",
-        "default": "./index.js"
+      "types": "./index.d.ts",
+      "default": "./index.js"
     }
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -7,10 +7,8 @@
   },
   "exports": {
     ".": {
-      "import": {
         "types": "./index.d.ts",
         "default": "./index.js"
-      }
     }
   },
   "files": [


### PR DESCRIPTION
The `exports` field in package.json was not formatted correctly, causing an `ERR_PACKAGE_PATH_NOT_EXPORTED` error:

```zsh
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in /path/to/repo/apps/app/node_modules/flat/package.json
```
Removing the nested `import` key fixes it.